### PR TITLE
Bugfix - App failure on issue comment

### DIFF
--- a/src/ContributorLicenseAgreement.Core/Handlers/IssueCommentHandler.cs
+++ b/src/ContributorLicenseAgreement.Core/Handlers/IssueCommentHandler.cs
@@ -120,11 +120,21 @@ namespace ContributorLicenseAgreement.Core.Handlers
                 gitOpsPayload.PlatformContext.InstallationId,
                 gitOpsPayload.PlatformContext.Dns);
 
-            var pr = await client.GetPullRequestAsync(
-                long.Parse(gitOpsPayload.PlatformContext.RepositoryId),
-                gitOpsPayload.PullRequestComment.PullRequestNumber);
-
-            return pr.User.Login.Equals(gitOpsPayload.PullRequestComment.User);
+            try
+            {
+                var pr = await client.GetPullRequestAsync(
+                    long.Parse(gitOpsPayload.PlatformContext.RepositoryId),
+                    gitOpsPayload.PullRequestComment.PullRequestNumber);
+                return pr.User.Login.Equals(gitOpsPayload.PullRequestComment.User);
+            }
+            catch
+            {
+                logger.LogInformation(
+                    "Unable to get pr {Number} for {Repo}",
+                    gitOpsPayload.PullRequestComment.PullRequestNumber,
+                    gitOpsPayload.PlatformContext.RepositoryName);
+                return false;
+            }
         }
 
         private (CommentAction, string) ParseComment(string comment, string host, ClaPrimitive primitive)


### PR DESCRIPTION
This bug happens when a user comments on an issue. Currently GitOps treats pr and issue comments the same. This makes it difficult to differentiate between the two. This fix prevents the app from failing. The bug did not impact any scenario.