### PR TITLE
Added functionality to recover from invalid db entries.

### DIFF
--- a/src/ContributorLicenseAgreement.Core/Handlers/PullRequestHandler.cs
+++ b/src/ContributorLicenseAgreement.Core/Handlers/PullRequestHandler.cs
@@ -136,11 +136,19 @@ namespace ContributorLicenseAgreement.Core.Handlers
 
             if (cla == null || (cla.Employee && cla.MsftMail == null))
             {
-                cla = await TryCreateCla(appOutput, gitOpsPayload, autoSignMsftEmployee, claLink);
-                if (cla == null)
+                var newCla = await TryCreateCla(appOutput, gitOpsPayload, autoSignMsftEmployee, claLink);
+                if (newCla == null)
                 {
+                    if (cla != null)
+                    {
+                        cla = await claHelper.ExpireCla(gitOpsPayload.PullRequest.User, claLink);
+                        appOutput.States = claHelper.GenerateStates(gitOpsPayload.PullRequest.User, claLink, cla);
+                    }
+
                     return false;
                 }
+
+                cla = newCla;
             }
 
             if (!cla.Employee)


### PR DESCRIPTION
If msftEmployee is set to true with the email being null and no github and msft-account linked, this change will allow the cla to recover and allow the user to re-sign.