### PR TITLE
Bugfix: Not acting on already closed prs

### DIFF
--- a/src/ContributorLicenseAgreement.Core/Handlers/PullRequestHandler.cs
+++ b/src/ContributorLicenseAgreement.Core/Handlers/PullRequestHandler.cs
@@ -79,6 +79,12 @@ namespace ContributorLicenseAgreement.Core.Handlers
                 return appOutput;
             }
 
+            if (gitOpsPayload.PullRequest.State == PullRequestState.Closed)
+            {
+                logger.LogInformation("Not acting on closed pull request");
+                return appOutput;
+            }
+
             if (NeedsLicense(primitive, gitOpsPayload.PullRequest))
             {
                 logger.LogInformation("License needed for {Sender}", gitOpsPayload.PullRequest.User);


### PR DESCRIPTION
This fixes a bug that caused the bot to act on old prs after another GitHub app unassigned users from said pr.